### PR TITLE
Thou shall not store VDF union coords in restart files

### DIFF
--- a/ioread.cpp
+++ b/ioread.cpp
@@ -833,6 +833,29 @@ bool _readBlockDataCompressionMLP(vlsv::ParallelReader & file,
          //Reconstruct this Union
          ASTERIX::VDFUnion vdf_union;
          vdf_union.deserialize_from(reinterpret_cast<unsigned char*>(mlp_bytes.data()));
+         vdf_union.vcoords_union.clear();
+
+         //Change the coords;
+         const std::size_t total_size=vdf_union.bbox_shape[0]*vdf_union.bbox_shape[1]*vdf_union.bbox_shape[2];
+         vdf_union.vcoords_union.reserve(total_size);
+         vdf_union.vspace_union.resize(total_size*vdf_union.ncols);
+         vdf_union.nrows=total_size;
+         
+         Real dvx_normalized= (2.0)/(Realf)vdf_union.bbox_shape[0];
+         Real dvy_normalized= (2.0)/(Realf)vdf_union.bbox_shape[1];
+         Real dvz_normalized= (2.0)/(Realf)vdf_union.bbox_shape[2];
+         std::cout<<dvx_normalized<<" "<<dvy_normalized<<" "<<dvz_normalized<<std::endl;
+         for (std::size_t i=0; i<vdf_union.bbox_shape[0];++i){
+            for (std::size_t j=0; j<vdf_union.bbox_shape[1];++j){
+               for (std::size_t k=0; k<vdf_union.bbox_shape[2];++k){
+                  const std::array<Real,3>coords={-1.0+i*dvx_normalized,-1.0+j*dvy_normalized,-1.0+k*dvz_normalized};
+                  vdf_union.vcoords_union.push_back(coords);
+               }
+            }
+         }
+         
+
+         std::cout<<"Read "<<vdf_union.nrows<<std::endl;
          ASTERIX::uncompress_union(vdf_union);
          unnormalize_vspace_coords (vdf_union);
          vdf_union.unormalize_union();
@@ -843,17 +866,26 @@ bool _readBlockDataCompressionMLP(vlsv::ParallelReader & file,
          for (const auto& [cid,mlpid]:cid2mlp_map){
             if (mlpid==id){
                SpatialCell* sc=mpiGrid[cid];
+               ASTERIX::OrderedVDF new_vdf;
+               new_vdf.v_limits=vdf_union.v_limits;
+               new_vdf.shape=vdf_union.bbox_shape;
                const std::size_t column=std::find(vdf_union.cids.begin(),vdf_union.cids.end(),cid)-vdf_union.cids.begin();
                for (std::size_t i=0; i< vdf_union.nrows;++i){
                   auto vbulk=vdf_union.vbulk_union[column];
                   auto coords=vdf_union.vcoords_union[i];
                   coords[0]+=vbulk.vx; coords[1]+=vbulk.vy;coords[2]+=vbulk.vz;  
                   const auto gid=sc->get_velocity_block(popID, &coords[0]);
-                  if (vdf_union.vspace_union[vdf_union.index_2d(i,column)]>=sparse){
+                  bool ignore= std::find(vdf_union.blocks_ignore.begin(),vdf_union.blocks_ignore.end(),gid) != vdf_union.blocks_ignore.end();
+                  if (vdf_union.vspace_union[vdf_union.index_2d(i,column)]>=sparse && !ignore){
                      sc->add_velocity_block(gid,popID);
+                     new_vdf.vdf_vals.push_back(vdf_union.vspace_union.at(vdf_union.index_2d(i,column)));
+                  }else{
+                     new_vdf.vdf_vals.push_back(0);
                   }
                }
-               ASTERIX::overwrite_cellids_vdf_single_cell(vdf_union.cids, popID,sc,column,vdf_union.vcoords_union, vdf_union.vspace_union, vdf_union.map);
+               // ASTERIX::overwrite_cellids_vdf_single_cell(vdf_union.cids, popID,sc,column,vdf_union.vcoords_union, vdf_union.vspace_union, vdf_union.map);
+               ASTERIX::overwrite_pop_spatial_cell_vdf_ignore(sc, popID, new_vdf,vdf_union.blocks_ignore);
+               // sc->adjustSingleCellVelocityBlocks(popID);
             }
          }
       }else{
@@ -863,6 +895,19 @@ bool _readBlockDataCompressionMLP(vlsv::ParallelReader & file,
             return false;
          }
       }
+   }
+
+   std::vector<CellID> cids;
+   for (std::size_t i=0;i<localCells;++i){
+      cids.push_back(fileCells[localCellStartOffset+i]);
+   }
+   adjustVelocityBlocks(mpiGrid,cids, false,popID );
+   for (std::size_t i=0;i<localCells;++i){
+      auto cid=fileCells[localCellStartOffset+i];
+      std::string fname = "vdf_" + std::to_string(cid) + "_pre.bin";
+      std::string fname2 = "vdf_" + std::to_string(cid) + "_post.bin";
+      ASTERIX::dump_vdf_to_binary_file(fname.c_str(),cid,mpiGrid);
+      ASTERIX::dump_vdf_to_binary_file(fname2.c_str(),cid,mpiGrid);
    }
    return success;  
 }

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -841,10 +841,9 @@ bool _readBlockDataCompressionMLP(vlsv::ParallelReader & file,
          vdf_union.vspace_union.resize(total_size*vdf_union.ncols);
          vdf_union.nrows=total_size;
          
-         Real dvx_normalized= (2.0)/(Realf)vdf_union.bbox_shape[0];
-         Real dvy_normalized= (2.0)/(Realf)vdf_union.bbox_shape[1];
-         Real dvz_normalized= (2.0)/(Realf)vdf_union.bbox_shape[2];
-         std::cout<<dvx_normalized<<" "<<dvy_normalized<<" "<<dvz_normalized<<std::endl;
+         const Real dvx_normalized= (2.0)/(Realf)vdf_union.bbox_shape[0];
+         const Real dvy_normalized= (2.0)/(Realf)vdf_union.bbox_shape[1];
+         const Real dvz_normalized= (2.0)/(Realf)vdf_union.bbox_shape[2];
          for (std::size_t i=0; i<vdf_union.bbox_shape[0];++i){
             for (std::size_t j=0; j<vdf_union.bbox_shape[1];++j){
                for (std::size_t k=0; k<vdf_union.bbox_shape[2];++k){
@@ -854,8 +853,6 @@ bool _readBlockDataCompressionMLP(vlsv::ParallelReader & file,
             }
          }
          
-
-         std::cout<<"Read "<<vdf_union.nrows<<std::endl;
          ASTERIX::uncompress_union(vdf_union);
          unnormalize_vspace_coords (vdf_union);
          vdf_union.unormalize_union();
@@ -869,23 +866,25 @@ bool _readBlockDataCompressionMLP(vlsv::ParallelReader & file,
                ASTERIX::OrderedVDF new_vdf;
                new_vdf.v_limits=vdf_union.v_limits;
                new_vdf.shape=vdf_union.bbox_shape;
-               const std::size_t column=std::find(vdf_union.cids.begin(),vdf_union.cids.end(),cid)-vdf_union.cids.begin();
+               const auto it=std::find(vdf_union.cids.begin(),vdf_union.cids.end(),cid);
+               if (it==vdf_union.cids.end()){
+                  throw std::runtime_error("Catastrophic failure in MLP reconstruction while trying to find cellid in union that was supposed to own it");
+               }
+               const std::size_t column=it-vdf_union.cids.begin();
                for (std::size_t i=0; i< vdf_union.nrows;++i){
-                  auto vbulk=vdf_union.vbulk_union[column];
+                  const auto vbulk=vdf_union.vbulk_union[column];
                   auto coords=vdf_union.vcoords_union[i];
                   coords[0]+=vbulk.vx; coords[1]+=vbulk.vy;coords[2]+=vbulk.vz;  
                   const auto gid=sc->get_velocity_block(popID, &coords[0]);
-                  bool ignore= std::find(vdf_union.blocks_ignore.begin(),vdf_union.blocks_ignore.end(),gid) != vdf_union.blocks_ignore.end();
+                  const bool ignore= std::find(vdf_union.blocks_ignore.begin(),vdf_union.blocks_ignore.end(),gid) != vdf_union.blocks_ignore.end();
                   if (vdf_union.vspace_union[vdf_union.index_2d(i,column)]>=sparse && !ignore){
                      sc->add_velocity_block(gid,popID);
                      new_vdf.vdf_vals.push_back(vdf_union.vspace_union.at(vdf_union.index_2d(i,column)));
                   }else{
-                     new_vdf.vdf_vals.push_back(0);
+                     new_vdf.vdf_vals.push_back(Realf(0));//something to be eaten by sparsity 
                   }
                }
-               // ASTERIX::overwrite_cellids_vdf_single_cell(vdf_union.cids, popID,sc,column,vdf_union.vcoords_union, vdf_union.vspace_union, vdf_union.map);
                ASTERIX::overwrite_pop_spatial_cell_vdf_ignore(sc, popID, new_vdf,vdf_union.blocks_ignore);
-               // sc->adjustSingleCellVelocityBlocks(popID);
             }
          }
       }else{
@@ -902,13 +901,6 @@ bool _readBlockDataCompressionMLP(vlsv::ParallelReader & file,
       cids.push_back(fileCells[localCellStartOffset+i]);
    }
    adjustVelocityBlocks(mpiGrid,cids, false,popID );
-   for (std::size_t i=0;i<localCells;++i){
-      auto cid=fileCells[localCellStartOffset+i];
-      std::string fname = "vdf_" + std::to_string(cid) + "_pre.bin";
-      std::string fname2 = "vdf_" + std::to_string(cid) + "_post.bin";
-      ASTERIX::dump_vdf_to_binary_file(fname.c_str(),cid,mpiGrid);
-      ASTERIX::dump_vdf_to_binary_file(fname2.c_str(),cid,mpiGrid);
-   }
    return success;  
 }
 

--- a/vdf_compression/compression.cpp
+++ b/vdf_compression/compression.cpp
@@ -208,23 +208,10 @@ float compress_vdfs_fourier_mlp(dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geome
              vdf_union.network_weights, network_size, false, downsampling_factor, error, status);
 
          assert(network_size == nn_mem_footprint_bytes && "Mismatch betweeen estimated and actual network size!!!");
-
          
          bytes.resize(vdf_union.total_serialized_size_bytes());
          vdf_union.serialize_into(reinterpret_cast<unsigned char*>(&bytes[0]));
-         // vdf_union.print();
-
-         
-         // new_union.deserialize_from(&bytes[0]);
-
-         // uncompress_vdf_union(span.size(), vdf_union.vcoords_union.data(), vdf_union.vspace_union.data(),
-         //                      vdf_union.vcoords_union.size(), P::mlp_fourier_order, P::mlp_arch.data(),
-         //                      P::mlp_arch.size(), vdf_union.network_weights, network_size, true);
-
          local_compression_achieved += vdf_union.size_in_bytes / static_cast<float>(nn_mem_footprint_bytes);
-         // vdf_union.unormalize_union();
-         // vdf_union.unscale(sparse);
-         // vdf_union.sparsify(sparse);
          free(vdf_union.network_weights);
 
          // (3) Overwrite the VDF of this cell
@@ -355,7 +342,7 @@ float compress_vdfs_fourier_mlp_clustered(dccrg::Dccrg<SpatialCell, dccrg::Carte
          vdf_union.sparsify(sparse);
 
          // (3) Overwrite the VDF of this cell
-         overwrite_cellids_vdfs(span, popID, mpiGrid, vdf_union.vcoords_union, vdf_union.vspace_union, vdf_union.map);
+         // overwrite_cellids_vdfs(span, popID, mpiGrid, vdf_union.vcoords_union, vdf_union.vspace_union, vdf_union.map);
       }
    } // loop over all populations
    return local_compression_achieved / static_cast<float>(total_samples);

--- a/vdf_compression/compression_tools.cpp
+++ b/vdf_compression/compression_tools.cpp
@@ -144,7 +144,8 @@ void ASTERIX::overwrite_pop_spatial_cell_vdf(SpatialCell* sc, uint popID, const 
    return;
 }
 
-void ASTERIX::overwrite_pop_spatial_cell_vdf_ignore(SpatialCell* sc, uint popID, const OrderedVDF& vdf,const std::vector<std::size_t>& ignore_list) {
+void ASTERIX::overwrite_pop_spatial_cell_vdf_ignore(SpatialCell* sc, uint popID, const OrderedVDF& vdf,
+                                                    const std::vector<std::size_t>& ignore_list) {
    assert(sc && "Invalid Pointer to Spatial Cell !");
    vmesh::VelocityBlockContainer<vmesh::LocalID>& blockContainer = sc->get_velocity_blocks(popID);
    const size_t total_blocks = blockContainer.size();
@@ -155,9 +156,9 @@ void ASTERIX::overwrite_pop_spatial_cell_vdf_ignore(SpatialCell* sc, uint popID,
    assert(data && "Invalid Pointre block container data");
 
    for (std::size_t n = 0; n < total_blocks; ++n) {
-      const auto gid=sc->get_velocity_block_global_id(n,popID );
-      bool ignore=std::find(ignore_list.begin(),ignore_list.end(),gid)!=ignore_list.end();
-      if (ignore){
+      const auto gid = sc->get_velocity_block_global_id(n, popID);
+      bool ignore = std::find(ignore_list.begin(), ignore_list.end(), gid) != ignore_list.end();
+      if (ignore) {
          continue;
       }
       auto bp = blockParams + n * BlockParams::N_VELOCITY_BLOCK_PARAMS;
@@ -186,7 +187,6 @@ void ASTERIX::overwrite_pop_spatial_cell_vdf_ignore(SpatialCell* sc, uint popID,
    return;
 }
 
-
 ASTERIX::VDFUnion
 ASTERIX::extract_union_pop_vdfs_from_cids(const std::span<const CellID> cids, uint popID,
                                           const dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
@@ -210,8 +210,9 @@ ASTERIX::extract_union_pop_vdfs_from_cids(const std::span<const CellID> cids, ui
                              std::numeric_limits<Real>::lowest(), std::numeric_limits<Real>::lowest()};
 
    VDFUnion vdf_union{};
+   std::unordered_map<vmesh::LocalID, std::size_t> map;
    std::vector<VCoords> vbulk_union;
-   Real dv;
+   Real dv = 0.0; // FIXME
    for (std::size_t cc = 0; cc < cids.size(); ++cc) {
       const auto& cid = cids[cc];
       vdf_union.cids.push_back(cid);
@@ -229,7 +230,7 @@ ASTERIX::extract_union_pop_vdfs_from_cids(const std::span<const CellID> cids, ui
          const vmesh::GlobalID gid = sc->get_velocity_block_global_id(n, popID);
          const Realf* vdf_data = &data[n * WID3];
 
-         auto [it, block_inserted] = vdf_union.map.try_emplace(gid, vdf_union.vcoords_union.size());
+         auto [it, block_inserted] = map.try_emplace(gid, vdf_union.vcoords_union.size());
          std::size_t cnt = 0;
          for (uint k = 0; k < WID; ++k) {
             for (uint j = 0; j < WID; ++j) {
@@ -266,52 +267,33 @@ ASTERIX::extract_union_pop_vdfs_from_cids(const std::span<const CellID> cids, ui
       }
    }
 
-   std::cout<<"First pass = "<<vspaces.front().size()<<std::endl;
-
+   // Continues on to extract the bounding box GID. Those are used in training but ignored in inference during restart
+   // reading
    std::vector<std::size_t> blocks_ignore;
+   const std::array<std::size_t, 3> bbox_shape{static_cast<std::size_t>(std::floor((vlims[3] - vlims[0]) / dv)) + 1,
+                                         static_cast<std::size_t>(std::floor((vlims[4] - vlims[1]) / dv)) + 1,
+                                         static_cast<std::size_t>(std::floor((vlims[5] - vlims[2]) / dv)) + 1};
 
-   //Now we have sort of a bounding box of the union given by vlims and dv;
-   std::array<std::size_t,3>bbox_shape;
-   bbox_shape[0] = static_cast<std::size_t>(std::floor((vlims[3] - vlims[0]) / dv)) + 1;
-   bbox_shape[1] = static_cast<std::size_t>(std::floor((vlims[4] - vlims[1]) / dv)) + 1;
-   bbox_shape[2] = static_cast<std::size_t>(std::floor((vlims[5] - vlims[2]) / dv)) + 1;
-   for (std::size_t i=0;i<bbox_shape[0];++i){
-      for (std::size_t j=0;j<bbox_shape[1];++j){
-         for (std::size_t k=0;k<bbox_shape[2];++k){
-            std::array<Real,3> coords={vlims[0]+i*dv,vlims[1]+j*dv,vlims[2]+k*dv};
-            const auto gid=mpiGrid[cids.front()]->get_velocity_block(popID, &coords[0]);
-            assert(gid>=0);
-            auto [it, block_inserted] = vdf_union.map.try_emplace(gid, vdf_union.vcoords_union.size());
-            if (block_inserted){
+                                      
+   for (std::size_t i = 0; i < bbox_shape[0]; ++i) {
+      for (std::size_t j = 0; j < bbox_shape[1]; ++j) {
+         for (std::size_t k = 0; k < bbox_shape[2]; ++k) {
+            const std::array<Real, 3> coords = {vlims[0] + i * dv, vlims[1] + j * dv, vlims[2] + k * dv};
+            const auto gid = mpiGrid[cids.front()]->get_velocity_block(popID, &coords[0]);
+            auto [it, block_inserted] = map.try_emplace(gid, vdf_union.vcoords_union.size());
+            if (block_inserted) {
                blocks_ignore.push_back(gid);
-            //    for (int kk =-WID; kk < WID; ++kk) {
-            //       for (int jj = -WID; jj < WID; ++jj) {
-            //          for (int ii = -WID; ii < WID; ++ii) {
-            //             coords[0]+=ii*dv;
-            //             coords[1]+=jj*dv;
-            //             coords[2]+=kk*dv;
-            //             if (coords[0]>vlims[0] && coords[1]>vlims[1] && coords[2]>vlims[2] && coords[0]<vlims[3] && coords[1]<vlims[4] && coords[2]<vlims[5] ){
-            //                vdf_union.vcoords_union.push_back({coords[0], coords[1], coords[2]});
-            //                for (std::size_t x = 0; x < cids.size(); ++x) {
-            //                   vspaces[x].push_back(Realf(0));
-            //                }
-            //             }
-            //          }
-            //       }
-            //    }
             }
          }
       }
    }
-   
-   std::cout<<"Ignore list  = "<<blocks_ignore.size()<<std::endl;
 
    const std::size_t nrows = vspaces.front().size();
    const std::size_t ncols = cids.size();
-   vdf_union.nrows=nrows;
-   vdf_union.ncols=ncols;
-   vdf_union.blocks_ignore=blocks_ignore;
-   vdf_union.bbox_shape=bbox_shape;
+   vdf_union.nrows = nrows;
+   vdf_union.ncols = ncols;
+   vdf_union.blocks_ignore = blocks_ignore;
+   vdf_union.bbox_shape = bbox_shape;
    // This will be used further down for indexing into the vspace_union
    auto index_2d = [nrows, ncols](std::size_t row, std::size_t col) -> std::size_t { return row * ncols + col; };
 
@@ -418,132 +400,10 @@ ASTERIX::OrderedVDF ASTERIX::extract_pop_vdf_from_spatial_cell_ordered_min_bbox_
          }
       }
    } // over blocks
-   return ASTERIX::OrderedVDF{.sparse_vdf_bytes=total_blocks*WID*WID*WID*sizeof(Realf),.vdf_vals = vspace, .v_limits = vlims, .shape = {nx, ny, nz}};
-}
-
-void ASTERIX::overwrite_cellids_vdfs(const std::span<const CellID> cids, uint popID,
-                                     dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
-                                     const std::vector<std::array<Real, 3>>& vcoords,
-                                     const std::vector<Realf>& vspace_union,
-                                     const std::unordered_map<vmesh::LocalID, std::size_t>& map_exists_id) {
-   const std::size_t nrows = vcoords.size();
-   const std::size_t ncols = cids.size();
-   // This will be used further down for indexing into the vspace_union
-   auto index_2d = [nrows, ncols](std::size_t row, std::size_t col) -> std::size_t { return row * ncols + col; };
-
-   for (std::size_t cc = 0; cc < cids.size(); ++cc) {
-      const auto& cid = cids[cc];
-      SpatialCell* sc = mpiGrid[cid];
-      vmesh::VelocityBlockContainer<vmesh::LocalID>& blockContainer = sc->get_velocity_blocks(popID);
-      const size_t total_blocks = blockContainer.size();
-      Realf* data = blockContainer.getData();
-      const Real* blockParams = sc->get_block_parameters(popID);
-      for (std::size_t n = 0; n < total_blocks; ++n) {
-         const auto bp = blockParams + n * BlockParams::N_VELOCITY_BLOCK_PARAMS;
-         const vmesh::GlobalID gid = sc->get_velocity_block_global_id(n, popID);
-         const auto it = map_exists_id.find(gid);
-         const bool exists = it != map_exists_id.end();
-         if (!exists){
-            std::cerr<<"This should not happen!"<<std::endl;
-            abort();
-         }
-         assert(exists && "Someone has a buuuug!");
-         const auto index = it->second;
-         Realf* vdf_data = &data[n * WID3];
-         size_t cnt = 0;
-         for (uint k = 0; k < WID; ++k) {
-            for (uint j = 0; j < WID; ++j) {
-               for (uint i = 0; i < WID; ++i) {
-                  const std::size_t index = it->second;
-                  vdf_data[cellIndex(i, j, k)] = vspace_union[index_2d(index + cnt, cc)];
-                  cnt++;
-               }
-            }
-         }
-      }
-   }
-   return;
-}
-
-void ASTERIX::overwrite_cellids_vdf_single_cell(const std::span<const CellID> cids, uint popID, SpatialCell* sc, size_t cc,
-                                     const std::vector<std::array<Real, 3>>& vcoords,
-                                     const std::vector<Realf>& vspace_union,
-                                     const std::unordered_map<vmesh::LocalID, std::size_t>& map_exists_id) {
-   const std::size_t nrows = vcoords.size();
-   const std::size_t ncols = cids.size();
-   // This will be used further down for indexing into the vspace_union
-   auto index_2d = [nrows, ncols](std::size_t row, std::size_t col) -> std::size_t { return row * ncols + col; };
-
-   const auto& cid = cids[cc];
-   vmesh::VelocityBlockContainer<vmesh::LocalID>& blockContainer = sc->get_velocity_blocks(popID);
-   const size_t total_blocks = blockContainer.size();
-   Realf* data = blockContainer.getData();
-   const Real* blockParams = sc->get_block_parameters(popID);
-   for (std::size_t n = 0; n < total_blocks; ++n) {
-      const auto bp = blockParams + n * BlockParams::N_VELOCITY_BLOCK_PARAMS;
-      const vmesh::GlobalID gid = sc->get_velocity_block_global_id(n, popID);
-      const auto it = map_exists_id.find(gid);
-      const bool exists = it != map_exists_id.end();
-      if (!exists){
-         std::cerr<<"This should not happen!"<<std::endl;
-
-         abort();
-      }
-      assert(exists && "Someone has a buuuug!");
-      const auto index = it->second;
-      Realf* vdf_data = &data[n * WID3];
-      size_t cnt = 0;
-      for (uint k = 0; k < WID; ++k) {
-         for (uint j = 0; j < WID; ++j) {
-            for (uint i = 0; i < WID; ++i) {
-               const std::size_t index = it->second;
-               vdf_data[cellIndex(i, j, k)] = vspace_union[index_2d(index + cnt, cc)];
-               cnt++;
-            }
-         }
-      }
-   }
-   return;
-}
-
-void ASTERIX::overwrite_cellids_vdf_single_cell2(const std::span<const CellID> cids, uint popID, SpatialCell* sc, size_t cc,
-                                     const std::vector<std::array<Real, 3>>& vcoords,
-                                     const std::vector<Realf>& vspace_union,
-                                     const std::unordered_map<vmesh::LocalID, std::size_t>& map_exists_id) {
-   const std::size_t nrows = vcoords.size();
-   const std::size_t ncols = cids.size();
-   // This will be used further down for indexing into the vspace_union
-   auto index_2d = [nrows, ncols](std::size_t row, std::size_t col) -> std::size_t { return row * ncols + col; };
-
-   const auto& cid = cids[cc];
-   vmesh::VelocityBlockContainer<vmesh::LocalID>& blockContainer = sc->get_velocity_blocks(popID);
-   const size_t total_blocks = blockContainer.size();
-   Realf* data = blockContainer.getData();
-   const Real* blockParams = sc->get_block_parameters(popID);
-   for (std::size_t n = 0; n < total_blocks; ++n) {
-      const auto bp = blockParams + n * BlockParams::N_VELOCITY_BLOCK_PARAMS;
-      const vmesh::GlobalID gid = sc->get_velocity_block_global_id(n, popID);
-      const auto it = map_exists_id.find(gid);
-      const bool exists = it != map_exists_id.end();
-      if (!exists){
-         std::cerr<<"This should not happen!"<<std::endl;
-         abort();
-      }
-      assert(exists && "Someone has a buuuug!");
-      const auto index = it->second;
-      Realf* vdf_data = &data[n * WID3];
-      size_t cnt = 0;
-      for (uint k = 0; k < WID; ++k) {
-         for (uint j = 0; j < WID; ++j) {
-            for (uint i = 0; i < WID; ++i) {
-               const std::size_t index = it->second;
-               vdf_data[cellIndex(i, j, k)] = vspace_union[index_2d(index + cnt, cc)];
-               cnt++;
-            }
-         }
-      }
-   }
-   return;
+   return ASTERIX::OrderedVDF{.sparse_vdf_bytes = total_blocks * WID * WID * WID * sizeof(Realf),
+                              .vdf_vals = vspace,
+                              .v_limits = vlims,
+                              .shape = {nx, ny, nz}};
 }
 
 void ASTERIX::dump_vdf_to_binary_file(const char* filename, CellID cid,

--- a/vdf_compression/compression_tools.cpp
+++ b/vdf_compression/compression_tools.cpp
@@ -144,6 +144,49 @@ void ASTERIX::overwrite_pop_spatial_cell_vdf(SpatialCell* sc, uint popID, const 
    return;
 }
 
+void ASTERIX::overwrite_pop_spatial_cell_vdf_ignore(SpatialCell* sc, uint popID, const OrderedVDF& vdf,const std::vector<std::size_t>& ignore_list) {
+   assert(sc && "Invalid Pointer to Spatial Cell !");
+   vmesh::VelocityBlockContainer<vmesh::LocalID>& blockContainer = sc->get_velocity_blocks(popID);
+   const size_t total_blocks = blockContainer.size();
+   const Real* blockParams = sc->get_block_parameters(popID);
+   Realf* data = blockContainer.getData();
+   assert(max_v_lims && "Invalid Pointre to max_v_limits");
+   assert(min_v_lims && "Invalid Pointre to min_v_limits");
+   assert(data && "Invalid Pointre block container data");
+
+   for (std::size_t n = 0; n < total_blocks; ++n) {
+      const auto gid=sc->get_velocity_block_global_id(n,popID );
+      bool ignore=std::find(ignore_list.begin(),ignore_list.end(),gid)!=ignore_list.end();
+      if (ignore){
+         continue;
+      }
+      auto bp = blockParams + n * BlockParams::N_VELOCITY_BLOCK_PARAMS;
+      Realf* vdf_data = &data[n * WID3];
+      for (uint k = 0; k < WID; ++k) {
+         for (uint j = 0; j < WID; ++j) {
+            for (uint i = 0; i < WID; ++i) {
+               const Real dvx = (blockParams + BlockParams::N_VELOCITY_BLOCK_PARAMS)[BlockParams::DVX];
+               const Real dvy = (blockParams + BlockParams::N_VELOCITY_BLOCK_PARAMS)[BlockParams::DVY];
+               const Real dvz = (blockParams + BlockParams::N_VELOCITY_BLOCK_PARAMS)[BlockParams::DVZ];
+               const std::size_t nx = std::ceil((vdf.v_limits[3] - vdf.v_limits[0]) / dvx);
+               const std::size_t ny = std::ceil((vdf.v_limits[4] - vdf.v_limits[1]) / dvy);
+               const std::size_t nz = std::ceil((vdf.v_limits[5] - vdf.v_limits[2]) / dvz);
+               const Real vx = bp[BlockParams::VXCRD] + (i + 0.5) * bp[BlockParams::DVX];
+               const Real vy = bp[BlockParams::VYCRD] + (j + 0.5) * bp[BlockParams::DVY];
+               const Real vz = bp[BlockParams::VZCRD] + (k + 0.5) * bp[BlockParams::DVZ];
+               const size_t bbox_i = std::min(static_cast<size_t>(std::floor((vx - vdf.v_limits[0]) / dvx)), nx - 1);
+               const size_t bbox_j = std::min(static_cast<size_t>(std::floor((vy - vdf.v_limits[1]) / dvy)), ny - 1);
+               const size_t bbox_k = std::min(static_cast<size_t>(std::floor((vz - vdf.v_limits[2]) / dvz)), nz - 1);
+
+               vdf_data[cellIndex(i, j, k)] = vdf.at(bbox_i, bbox_j, bbox_k);
+            }
+         }
+      }
+   } // over blocks
+   return;
+}
+
+
 ASTERIX::VDFUnion
 ASTERIX::extract_union_pop_vdfs_from_cids(const std::span<const CellID> cids, uint popID,
                                           const dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
@@ -168,6 +211,7 @@ ASTERIX::extract_union_pop_vdfs_from_cids(const std::span<const CellID> cids, ui
 
    VDFUnion vdf_union{};
    std::vector<VCoords> vbulk_union;
+   Real dv;
    for (std::size_t cc = 0; cc < cids.size(); ++cc) {
       const auto& cid = cids[cc];
       vdf_union.cids.push_back(cid);
@@ -191,6 +235,7 @@ ASTERIX::extract_union_pop_vdfs_from_cids(const std::span<const CellID> cids, ui
             for (uint j = 0; j < WID; ++j) {
                for (uint i = 0; i < WID; ++i) {
 
+                  dv = bp[BlockParams::DVX];
                   VCoords coords = VCoords{bp[BlockParams::VXCRD] + (i + 0.5) * bp[BlockParams::DVX],
                                            bp[BlockParams::VYCRD] + (j + 0.5) * bp[BlockParams::DVY],
                                            bp[BlockParams::VZCRD] + (k + 0.5) * bp[BlockParams::DVZ]};
@@ -221,10 +266,52 @@ ASTERIX::extract_union_pop_vdfs_from_cids(const std::span<const CellID> cids, ui
       }
    }
 
+   std::cout<<"First pass = "<<vspaces.front().size()<<std::endl;
+
+   std::vector<std::size_t> blocks_ignore;
+
+   //Now we have sort of a bounding box of the union given by vlims and dv;
+   std::array<std::size_t,3>bbox_shape;
+   bbox_shape[0] = static_cast<std::size_t>(std::floor((vlims[3] - vlims[0]) / dv)) + 1;
+   bbox_shape[1] = static_cast<std::size_t>(std::floor((vlims[4] - vlims[1]) / dv)) + 1;
+   bbox_shape[2] = static_cast<std::size_t>(std::floor((vlims[5] - vlims[2]) / dv)) + 1;
+   for (std::size_t i=0;i<bbox_shape[0];++i){
+      for (std::size_t j=0;j<bbox_shape[1];++j){
+         for (std::size_t k=0;k<bbox_shape[2];++k){
+            std::array<Real,3> coords={vlims[0]+i*dv,vlims[1]+j*dv,vlims[2]+k*dv};
+            const auto gid=mpiGrid[cids.front()]->get_velocity_block(popID, &coords[0]);
+            assert(gid>=0);
+            auto [it, block_inserted] = vdf_union.map.try_emplace(gid, vdf_union.vcoords_union.size());
+            if (block_inserted){
+               blocks_ignore.push_back(gid);
+            //    for (int kk =-WID; kk < WID; ++kk) {
+            //       for (int jj = -WID; jj < WID; ++jj) {
+            //          for (int ii = -WID; ii < WID; ++ii) {
+            //             coords[0]+=ii*dv;
+            //             coords[1]+=jj*dv;
+            //             coords[2]+=kk*dv;
+            //             if (coords[0]>vlims[0] && coords[1]>vlims[1] && coords[2]>vlims[2] && coords[0]<vlims[3] && coords[1]<vlims[4] && coords[2]<vlims[5] ){
+            //                vdf_union.vcoords_union.push_back({coords[0], coords[1], coords[2]});
+            //                for (std::size_t x = 0; x < cids.size(); ++x) {
+            //                   vspaces[x].push_back(Realf(0));
+            //                }
+            //             }
+            //          }
+            //       }
+            //    }
+            }
+         }
+      }
+   }
+   
+   std::cout<<"Ignore list  = "<<blocks_ignore.size()<<std::endl;
+
    const std::size_t nrows = vspaces.front().size();
    const std::size_t ncols = cids.size();
    vdf_union.nrows=nrows;
    vdf_union.ncols=ncols;
+   vdf_union.blocks_ignore=blocks_ignore;
+   vdf_union.bbox_shape=bbox_shape;
    // This will be used further down for indexing into the vspace_union
    auto index_2d = [nrows, ncols](std::size_t row, std::size_t col) -> std::size_t { return row * ncols + col; };
 
@@ -379,6 +466,47 @@ void ASTERIX::overwrite_cellids_vdfs(const std::span<const CellID> cids, uint po
 }
 
 void ASTERIX::overwrite_cellids_vdf_single_cell(const std::span<const CellID> cids, uint popID, SpatialCell* sc, size_t cc,
+                                     const std::vector<std::array<Real, 3>>& vcoords,
+                                     const std::vector<Realf>& vspace_union,
+                                     const std::unordered_map<vmesh::LocalID, std::size_t>& map_exists_id) {
+   const std::size_t nrows = vcoords.size();
+   const std::size_t ncols = cids.size();
+   // This will be used further down for indexing into the vspace_union
+   auto index_2d = [nrows, ncols](std::size_t row, std::size_t col) -> std::size_t { return row * ncols + col; };
+
+   const auto& cid = cids[cc];
+   vmesh::VelocityBlockContainer<vmesh::LocalID>& blockContainer = sc->get_velocity_blocks(popID);
+   const size_t total_blocks = blockContainer.size();
+   Realf* data = blockContainer.getData();
+   const Real* blockParams = sc->get_block_parameters(popID);
+   for (std::size_t n = 0; n < total_blocks; ++n) {
+      const auto bp = blockParams + n * BlockParams::N_VELOCITY_BLOCK_PARAMS;
+      const vmesh::GlobalID gid = sc->get_velocity_block_global_id(n, popID);
+      const auto it = map_exists_id.find(gid);
+      const bool exists = it != map_exists_id.end();
+      if (!exists){
+         std::cerr<<"This should not happen!"<<std::endl;
+
+         abort();
+      }
+      assert(exists && "Someone has a buuuug!");
+      const auto index = it->second;
+      Realf* vdf_data = &data[n * WID3];
+      size_t cnt = 0;
+      for (uint k = 0; k < WID; ++k) {
+         for (uint j = 0; j < WID; ++j) {
+            for (uint i = 0; i < WID; ++i) {
+               const std::size_t index = it->second;
+               vdf_data[cellIndex(i, j, k)] = vspace_union[index_2d(index + cnt, cc)];
+               cnt++;
+            }
+         }
+      }
+   }
+   return;
+}
+
+void ASTERIX::overwrite_cellids_vdf_single_cell2(const std::span<const CellID> cids, uint popID, SpatialCell* sc, size_t cc,
                                      const std::vector<std::array<Real, 3>>& vcoords,
                                      const std::vector<Realf>& vspace_union,
                                      const std::unordered_map<vmesh::LocalID, std::size_t>& map_exists_id) {

--- a/vdf_compression/compression_tools.h
+++ b/vdf_compression/compression_tools.h
@@ -151,7 +151,6 @@ struct VDFUnion {
    std::array<std::size_t, 3> bbox_shape;
    std::vector<VCoords> vbulk_union;
    std::vector<Realf> vspace_union;
-   std::unordered_map<vmesh::LocalID, std::size_t> map;
    std::size_t size_in_bytes;
    double* network_weights = nullptr;
    std::size_t n_weights;
@@ -161,8 +160,8 @@ struct VDFUnion {
 
    std::size_t total_serialized_size_bytes() const {
       return sizeof(SerializedVDFUnionHeader) + cids.size() * sizeof(CellID)+ blocks_ignore.size()*sizeof(std::size_t) + bbox_shape.size()*sizeof(std::size_t) + norms.size() * sizeof(MinMaxValues) +
-             vbulk_union.size() * sizeof(VCoords) + vcoords_union.size() * 3 * sizeof(Real) + 6*sizeof(Real)+
-             n_weights * sizeof(double) + map.size() * sizeof(std::pair<vmesh::LocalID, std::size_t>);
+             vbulk_union.size() * sizeof(VCoords) + 6*sizeof(Real)+
+             n_weights * sizeof(double);
       ;
    }
 
@@ -176,16 +175,6 @@ struct VDFUnion {
       printf("Network size %zu\n",n_weights);
       printf("First weight %f\n ",network_weights[0]);
       printf("Last weight %f\n ",network_weights[n_weights-1]);
-      
-   for (int i=0;i<6;++i){
-      std::cout<<v_limits[i]<<", ";
-   }
-   std::cout<<std::endl;
-   std::cout<<"=========================="<<std::endl;
-      
-      // for (std::size_t i=0; i< nrows;++i){
-      //    printf("%zu %f %f %f\n",i,vcoords_union[i][0],vcoords_union[i][1],vcoords_union[i][2]);
-      // }
    }
 
 
@@ -221,19 +210,9 @@ struct VDFUnion {
       std::memcpy(&buffer[write_index], &v_limits[0],6 * sizeof(Real));
       write_index += 6 * sizeof(Real);
 
-      std::memcpy(&buffer[write_index], &vcoords_union[0], vcoords_union.size() * 3 * sizeof(Real));
-      write_index += vcoords_union.size() * 3 * sizeof(Real);
-
       std::memcpy(&buffer[write_index], &network_weights[0], n_weights * sizeof(double));
       write_index += n_weights * sizeof(double);
 
-      for (const auto& kval : map) {
-         std::memcpy(&buffer[write_index], &kval, sizeof(std::pair<vmesh::LocalID, std::size_t>));
-         write_index += sizeof(std::pair<vmesh::LocalID, std::size_t>);
-      }
-      
-      std::cout<<"Norms of 10"<<std::endl;
-      std::cout<<norms[10].max<<" "<<norms[10].mean<<" "<<norms[10].min<<std::endl;
       assert(header.total_size == write_index);
    }
 
@@ -242,7 +221,7 @@ struct VDFUnion {
       assert(header->key = MLP_KEY && "Blame Kostis Papadakis for this!");
 
       // Inflate vspave union
-      vspace_union.resize(header->cols * header->rows);
+      // vspace_union.resize(header->cols * header->rows);
       ncols = header->cols;
       nrows = header->rows;
 
@@ -275,11 +254,6 @@ struct VDFUnion {
       std::memcpy(&v_limits[0], &buffer[read_index], 6 * sizeof(Real));
       read_index +=  6 * sizeof(Real);
 
-      std::size_t vcoords_size = header->rows;
-      vcoords_union.resize(vcoords_size);
-      std::memcpy(vcoords_union.data(), &buffer[read_index], vcoords_size * 3 * sizeof(Real));
-      read_index += vcoords_size * 3 * sizeof(Real);
-
       if (network_weights != nullptr) {
          free(network_weights);
       }
@@ -288,16 +262,6 @@ struct VDFUnion {
       n_weights = header->n_weights;
       std::memcpy(network_weights, &buffer[read_index], header->n_weights * sizeof(double));
       read_index += n_weights * sizeof(double);
-
-      while (read_index < header->total_size) {
-         const std::pair<vmesh::LocalID, std::size_t>* kval =
-             reinterpret_cast<const std::pair<vmesh::LocalID, std::size_t>*>(&buffer[read_index]);
-         map[kval->first] = kval->second;
-         read_index += sizeof(std::pair<vmesh::LocalID, std::size_t>);
-      }
-      
-      std::cout<<"Norms of 10"<<std::endl;
-      std::cout<<norms[10].max<<" "<<norms[10].mean<<" "<<norms[10].min<<std::endl;
       assert(read_index == total_size && "Size mismatch while reading in serialized VDF Union!");
    }
 
@@ -412,21 +376,6 @@ auto overwrite_pop_spatial_cell_vdf(SpatialCell* sc, uint popID, const std::vect
 auto overwrite_pop_spatial_cell_vdf(SpatialCell* sc, uint popID, const OrderedVDF& vdf) -> void;
 
 auto overwrite_pop_spatial_cell_vdf_ignore(SpatialCell* sc, uint popID, const OrderedVDF& vdf,const std::vector<std::size_t>& ignore_list)->void;
-
-auto overwrite_cellids_vdfs(const std::span<const CellID> cids, uint popID,
-                            dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
-                            const std::vector<std::array<Real, 3>>& vcoords, const std::vector<Realf>& vspace_union,
-                            const std::unordered_map<vmesh::LocalID, std::size_t>& map_exists_id) -> void;
-
-auto overwrite_cellids_vdf_single_cell(const std::span<const CellID> cids, uint popID, SpatialCell* sc, size_t cc,
-                                     const std::vector<std::array<Real, 3>>& vcoords,
-                                     const std::vector<Realf>& vspace_union,
-                                     const std::unordered_map<vmesh::LocalID, std::size_t>& map_exists_id)->void; 
-
-auto overwrite_cellids_vdf_single_cell2(const std::span<const CellID> cids, uint popID, SpatialCell* sc, size_t cc,
-                                     const std::vector<std::array<Real, 3>>& vcoords,
-                                     const std::vector<Realf>& vspace_union,
-                                     const std::unordered_map<vmesh::LocalID, std::size_t>& map_exists_id)->void; 
 
 auto dump_vdf_to_binary_file(const char* filename, CellID cid) -> void;
 

--- a/vdf_compression/compression_tools.h
+++ b/vdf_compression/compression_tools.h
@@ -31,6 +31,7 @@
 #include "../object_wrapper.h"
 #include "../spatial_cell_wrapper.hpp"
 #include "../velocity_blocks.h"
+#include "concept_check.hpp"
 #include "stdlib.h"
 #include <algorithm>
 #include <array>
@@ -128,6 +129,7 @@ struct VDFUnion {
 
    struct MinMaxValues {
       Realf min = std::numeric_limits<Real>::lowest();
+
       Realf max = std::numeric_limits<Real>::max();
       Realf mean = 0.0;
    };
@@ -138,12 +140,15 @@ struct VDFUnion {
       std::size_t rows;
       std::size_t cols;
       std::size_t n_weights;
+      std::size_t ignore_size;
    };
 
    std::size_t nrows = 0, ncols = 0;
    std::vector<MinMaxValues> norms;
    std::vector<CellID> cids;
+   std::vector<std::size_t> blocks_ignore;
    std::vector<std::array<Real, 3>> vcoords_union;
+   std::array<std::size_t, 3> bbox_shape;
    std::vector<VCoords> vbulk_union;
    std::vector<Realf> vspace_union;
    std::unordered_map<vmesh::LocalID, std::size_t> map;
@@ -155,7 +160,7 @@ struct VDFUnion {
                                 std::numeric_limits<Real>::lowest(), std::numeric_limits<Real>::lowest()};
 
    std::size_t total_serialized_size_bytes() const {
-      return sizeof(SerializedVDFUnionHeader) + cids.size() * sizeof(CellID) + norms.size() * sizeof(MinMaxValues) +
+      return sizeof(SerializedVDFUnionHeader) + cids.size() * sizeof(CellID)+ blocks_ignore.size()*sizeof(std::size_t) + bbox_shape.size()*sizeof(std::size_t) + norms.size() * sizeof(MinMaxValues) +
              vbulk_union.size() * sizeof(VCoords) + vcoords_union.size() * 3 * sizeof(Real) + 6*sizeof(Real)+
              n_weights * sizeof(double) + map.size() * sizeof(std::pair<vmesh::LocalID, std::size_t>);
       ;
@@ -192,6 +197,7 @@ struct VDFUnion {
       header.rows = nrows;
       header.cols = ncols;
       header.n_weights = n_weights;
+      header.ignore_size=blocks_ignore.size();
       std::size_t write_index = 0;
 
       std::memcpy(&buffer[write_index], &header, sizeof(SerializedVDFUnionHeader));
@@ -199,6 +205,12 @@ struct VDFUnion {
 
       std::memcpy(&buffer[write_index], &cids[0], cids.size() * sizeof(CellID));
       write_index += cids.size() * sizeof(CellID);
+      
+      std::memcpy(&buffer[write_index], &blocks_ignore[0], blocks_ignore.size() * sizeof(std::size_t));
+      write_index +=  blocks_ignore.size() * sizeof(std::size_t);
+      
+      std::memcpy(&buffer[write_index], &bbox_shape[0], bbox_shape.size() * sizeof(std::size_t));
+      write_index +=  bbox_shape.size() * sizeof(std::size_t);
 
       std::memcpy(&buffer[write_index], &norms[0], norms.size() * sizeof(MinMaxValues));
       write_index += norms.size() * sizeof(MinMaxValues);
@@ -219,7 +231,9 @@ struct VDFUnion {
          std::memcpy(&buffer[write_index], &kval, sizeof(std::pair<vmesh::LocalID, std::size_t>));
          write_index += sizeof(std::pair<vmesh::LocalID, std::size_t>);
       }
-
+      
+      std::cout<<"Norms of 10"<<std::endl;
+      std::cout<<norms[10].max<<" "<<norms[10].mean<<" "<<norms[10].min<<std::endl;
       assert(header.total_size == write_index);
    }
 
@@ -235,10 +249,18 @@ struct VDFUnion {
       // Recover cids in this union;
       std::size_t read_index = sizeof(SerializedVDFUnionHeader);
       std::size_t cids_size = header->cols;
+      std::size_t ignore_size = header->ignore_size;
+      blocks_ignore.resize(ignore_size);
       cids.resize(cids_size);
 
       std::memcpy(cids.data(), &buffer[read_index], cids_size * sizeof(CellID));
       read_index += cids_size * sizeof(CellID);
+      
+      std::memcpy(blocks_ignore.data(), &buffer[read_index], ignore_size * sizeof(std::size_t));
+      read_index += ignore_size * sizeof(std::size_t);
+      
+      std::memcpy(bbox_shape.data(), &buffer[read_index], bbox_shape.size() * sizeof(std::size_t));
+      read_index += bbox_shape.size() * sizeof(std::size_t);
 
       std::size_t norms_size = cids_size;
       norms.resize(cids_size);
@@ -273,7 +295,9 @@ struct VDFUnion {
          map[kval->first] = kval->second;
          read_index += sizeof(std::pair<vmesh::LocalID, std::size_t>);
       }
-
+      
+      std::cout<<"Norms of 10"<<std::endl;
+      std::cout<<norms[10].max<<" "<<norms[10].mean<<" "<<norms[10].min<<std::endl;
       assert(read_index == total_size && "Size mismatch while reading in serialized VDF Union!");
    }
 
@@ -387,12 +411,19 @@ auto overwrite_pop_spatial_cell_vdf(SpatialCell* sc, uint popID, const std::vect
 
 auto overwrite_pop_spatial_cell_vdf(SpatialCell* sc, uint popID, const OrderedVDF& vdf) -> void;
 
+auto overwrite_pop_spatial_cell_vdf_ignore(SpatialCell* sc, uint popID, const OrderedVDF& vdf,const std::vector<std::size_t>& ignore_list)->void;
+
 auto overwrite_cellids_vdfs(const std::span<const CellID> cids, uint popID,
                             dccrg::Dccrg<SpatialCell, dccrg::Cartesian_Geometry>& mpiGrid,
                             const std::vector<std::array<Real, 3>>& vcoords, const std::vector<Realf>& vspace_union,
                             const std::unordered_map<vmesh::LocalID, std::size_t>& map_exists_id) -> void;
 
 auto overwrite_cellids_vdf_single_cell(const std::span<const CellID> cids, uint popID, SpatialCell* sc, size_t cc,
+                                     const std::vector<std::array<Real, 3>>& vcoords,
+                                     const std::vector<Realf>& vspace_union,
+                                     const std::unordered_map<vmesh::LocalID, std::size_t>& map_exists_id)->void; 
+
+auto overwrite_cellids_vdf_single_cell2(const std::span<const CellID> cids, uint popID, SpatialCell* sc, size_t cc,
                                      const std::vector<std::array<Real, 3>>& vcoords,
                                      const std::vector<Realf>& vspace_union,
                                      const std::unordered_map<vmesh::LocalID, std::size_t>& map_exists_id)->void; 


### PR DESCRIPTION
+ This will remain in a PR state until it has been rigorously tested. It removes the VDF union coordinates from the MLP states written in the restart files. To reconstruct the VDFs, a bounding box is created around the union during the restart reading process.

+ An ignore list of blocks is stored in the MLP states. After inference, all blocks in the ignore list are excluded, and the remaining blocks are used to reconstruct the VDFs. The blocks in the ignore list are specifically designed to include those that were not part of the training dataset but are now active in the inference region.